### PR TITLE
Fixed odd Klipper compatibility issue

### DIFF
--- a/adxl345_probe.py
+++ b/adxl345_probe.py
@@ -51,9 +51,13 @@ class ADXL345Endstop:
         if self.mcu_endstop not in hmove.get_mcu_endstops() or axis != self.axis:
             return
 
-        for stepper in self.adxl345probe.get_steppers(self.axis):
-            self.gcode.respond_info(stepper.get_name())
-            self.stepper_enable.motor_debug_enable(stepper.get_name(), True)
+        # Commented these out - they lead to errors when using ADXL for X and Y homing.
+        # This means that motors no longer engage before beginning homing
+        # - you'll have to do that yourself in your homing g-code. Can someone fix this?
+        
+        #for stepper in self.adxl345probe.get_steppers(self.axis):
+            #self.gcode.respond_info(stepper.get_name())
+            #self.stepper_enable.motor_debug_enable(stepper.get_name(), True)
         self.printer.lookup_object("toolhead").dwell(
             self.adxl345probe.stepper_enable_dwell_time
         )

--- a/adxl345_probe.py
+++ b/adxl345_probe.py
@@ -147,8 +147,13 @@ class ADXL345Probe:
             desc=self.cmd_SET_ACCEL_PROBE_help,
         )
         if self.enable_probe:
+            self.cmd_helper = probe.ProbeCommandHelper(config, self, self.query_endstop)
+            self.probe_offsets = probe.ProbeOffsetsHelper(config)
+            self.param_helper = probe.ProbeParameterHelper(config)
+            self.homing_helper = probe.HomingViaProbeHelper(config, self, self.param_helper)
+            self.probe_session = probe.ProbeSessionHelper(config, self.param_helper, self.homing_helper.start_probe_session)
             self.printer.add_object("probe", self)
-
+        
             self.tap_thresh_z = config.getfloat(
                 "tap_thresh_z", self.tap_thresh, minval=TAP_SCALE, maxval=100000.0
             )
@@ -232,6 +237,18 @@ class ADXL345Probe:
 
     def get_position_endstop(self):
         return self.position_endstop
+
+    def get_probe_params(self, gcmd=None):
+        return self.param_helper.get_probe_params(gcmd)
+
+    def get_offsets(self):
+        return self.probe_offsets.get_offsets()
+
+    def get_status(self, eventtime):
+        return self.cmd_helper.get_status(eventtime)
+
+    def start_probe_session(self, gcmd):
+        return self.probe_session.start_probe_session(gcmd)
 
     def _try_clear_tap(self):
         chip = self.adxl345


### PR DESCRIPTION
It's a little bit strange, but the LynxCrew fork of adxl345-probe refused to run for me. I tried Klipper 12 and 13 and neither worked, but I suspect it might have something to do with a change in Klipper based on comments in the original jniebuhr repository.

Errors were experienced such as "Option 'speed' is not valid in section 'adxl345_probe'" and "Internal error during connect: PrinterProbe.__init__() takes 2 positional arguments but 3 were given"

This commit restores some functions that were present in the original jniebuhr repository but removed in the LynxCrew fork, which "override" functions in class PrinterProbe in Klipper's probe.py. I'm not sure why they were removed, or under what circumstances the code would still run without them.

If I've missed something or there's a better way, please let me know.